### PR TITLE
Allow customizing hint color

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ You can customize the key binding in your `.tmux.conf`:
 set -g @jump-key 's'
 ```
 
+You can also customize foreground and background color:
+```
+set -g @jump-bg-color '\e[0m\e[90m'
+set -g @jump-fg-color '\e[1m\e[31m'
+```
+
 ## Similar Projects
 
 * [vimium](https://vimium.github.io/)

--- a/scripts/tmux-jump.rb
+++ b/scripts/tmux-jump.rb
@@ -4,9 +4,9 @@ require 'tempfile'
 require 'open3'
 
 # SPECIAL STRINGS
-GRAY = "\e[0m\e[32m"
+GRAY = ENV['JUMP_BACKGROUND_COLOR'].gsub('\e', "\e")
 # RED = "\e[38;5;124m"
-RED = "\e[1m\e[31m"
+RED = ENV['JUMP_FOREGROUND_COLOR'].gsub('\e', "\e")
 CLEAR_SEQ = "\e[2J"
 HOME_SEQ = "\e[H"
 RESET_COLORS = "\e[0m"

--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -4,4 +4,7 @@ tmp_file="$(mktemp)"
 tmux command-prompt -1 -p 'char:' "run-shell \"printf '%1' >> $tmp_file\""
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $current_dir/utils.sh
+export JUMP_BACKGROUND_COLOR=$(get_tmux_option "@jump-bg-color" "\e[0m\e[32m")
+export JUMP_FOREGROUND_COLOR=$(get_tmux_option "@jump-fg-color" "\e[1m\e[31m")
 ruby "$current_dir/tmux-jump.rb" "$tmp_file"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+get_tmux_option() {
+  local option=$1
+  local default_value=$2
+  local option_value=$(tmux show-option -gqv "$option")
+  if [ -z $option_value ]; then
+    echo $default_value
+  else
+    echo $option_value
+  fi
+}
+

--- a/tmux-jump.tmux
+++ b/tmux-jump.tmux
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-get_tmux_option() {
-  local option=$1
-  local default_value=$2
-  local option_value=$(tmux show-option -gqv "$option")
-  if [ -z $option_value ]; then
-    echo $default_value
-  else
-    echo $option_value
-  fi
-}
-
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $CURRENT_DIR/scripts/utils.sh
 tmux bind-key $(get_tmux_option "@jump-key" "j") run-shell -b "$CURRENT_DIR/scripts/tmux-jump.sh"


### PR DESCRIPTION
follow https://github.com/schasse/tmux-jump/pull/21 to add options:
```
set -g @jump-bg-color '\e[0m\e[90m'
set -g @jump-fg-color '\e[1m\e[31m'
```

screenshot:
![image](https://user-images.githubusercontent.com/20437334/85875260-8510b280-b806-11ea-8e0d-53c15cc316ea.png)

