### PR TITLE
Add @jump-keys-position

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ set -g @jump-bg-color '\e[0m\e[90m'
 set -g @jump-fg-color '\e[1m\e[31m'
 ```
 
+And the keys position:
+```
+# keys will overlap with the word (default)
+set -g @jump-keys-position 'left'
+
+# keys will be at the left of the word without overlap
+set -g @jump-keys-position 'off_left'
+```
+
 ## Similar Projects
 
 * [vimium](https://vimium.github.io/)

--- a/scripts/tmux-jump.rb
+++ b/scripts/tmux-jump.rb
@@ -14,6 +14,7 @@ ENTER_ALTERNATE_SCREEN = "\e[?1049h"
 RESTORE_NORMAL_SCREEN = "\e[?1049l"
 
 # CONFIG
+KEYS_POSITION = ENV['JUMP_KEYS_POSITION']
 KEYS = 'jfhgkdlsa'.each_char.to_a
 Config = Struct.new(
   :pane_nr,
@@ -148,7 +149,7 @@ def draw_keys_onto_tty(screen_chars, positions, keys, key_len)
     positions.each_with_index do |pos, i|
       tty << "#{GRAY}#{screen_chars[cursor..pos-1].gsub("\n", "\n\r")}"
       tty << "#{RED}#{keys[i]}"
-      cursor = pos + key_len
+      cursor = pos + key_len - (KEYS_POSITION == 'off_left' ? key_len : 0)
     end
     tty << "#{GRAY}#{screen_chars[cursor..-1].gsub("\n", "\n\r")}"
     tty << HOME_SEQ

--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -7,4 +7,5 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 export JUMP_BACKGROUND_COLOR=$(get_tmux_option "@jump-bg-color" "\e[0m\e[32m")
 export JUMP_FOREGROUND_COLOR=$(get_tmux_option "@jump-fg-color" "\e[1m\e[31m")
+export JUMP_KEYS_POSITION=$(get_tmux_option "@jump-keys-position" "left")
 ruby "$current_dir/tmux-jump.rb" "$tmp_file"


### PR DESCRIPTION
Hi, this means to add the option @jump-keys-position that can be set to:

```
keys will overlap with the word (default):
  set -g @jump-keys-position 'left'

keys will be at the left of the word without overlap:
  set -g @jump-keys-position 'off_left'
```
If you can, try it and tell me what do you think :)