### PR TITLE
Add tmux note to keybinding for list-keys

### DIFF
--- a/tmux-jump.tmux
+++ b/tmux-jump.tmux
@@ -2,4 +2,4 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/scripts/utils.sh
-tmux bind-key $(get_tmux_option "@jump-key" "j") run-shell -b "$CURRENT_DIR/scripts/tmux-jump.sh"
+tmux bind-key -N "Jump to pane location in copy mode" $(get_tmux_option "@jump-key" "j") run-shell -b "$CURRENT_DIR/scripts/tmux-jump.sh"


### PR DESCRIPTION
This PR simply adds a -N note so that the chosen key binding appears in `tmux list-keys` / `<prefix> + ?` and "Describe key binding" `<prefix> + /`, which is useful when you have a lot of custom keybindings.