### PR TITLE
Add support for two-characters typing + overall improvements

### DIFF
--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -2,6 +2,7 @@
 
 tmp_file="$(mktemp)"
 tmux command-prompt -1 -p 'char:' "run-shell \"printf '%1' >> $tmp_file\""
+tmux command-prompt -1 -p 'char:' "run-shell \"printf '%1' >> $tmp_file\""
 
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh

--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-tmp_file="$(mktemp)"
-tmux command-prompt -1 -p 'char:' "run-shell \"printf '%1' >> $tmp_file\""
-tmux command-prompt -1 -p 'char:' "run-shell \"printf '%1' >> $tmp_file\""
-
 current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $current_dir/utils.sh
 export JUMP_BACKGROUND_COLOR=$(get_tmux_option "@jump-bg-color" "\e[0m\e[32m")
 export JUMP_FOREGROUND_COLOR=$(get_tmux_option "@jump-fg-color" "\e[1m\e[31m")
 export JUMP_KEYS_POSITION=$(get_tmux_option "@jump-keys-position" "left")
-ruby "$current_dir/tmux-jump.rb" "$tmp_file"
+ruby "$current_dir/tmux-jump.rb"


### PR DESCRIPTION
Closes #42

This PR is not ready yet. I'd like to make this behave pretty much like vim easymotion. So when you type in the first character, the preview will already update and then again once you enter the second character.

I also wanna make sure we can use this in copy mode. Currently, we can only use `tmux-jump` starting from _normal_ mode and not within copy mode.

Btw, very good code! :) Even though I haven't worked with Ruby at all so far, after watching a short video about it, I was able to understand your code pretty quickly and could contribute to it!