### PR TITLE
Add support for user-defined jump keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ set -g @jump-keys-position 'left'
 set -g @jump-keys-position 'off_left'
 ```
 
+And the keys:
+```
+set -g @jump-keys 'aoeuidhtns'
+```
+
 ## Similar Projects
 
 * [vimium](https://vimium.github.io/)

--- a/scripts/tmux-jump.rb
+++ b/scripts/tmux-jump.rb
@@ -15,7 +15,7 @@ RESTORE_NORMAL_SCREEN = "\e[?1049l"
 
 # CONFIG
 KEYS_POSITION = ENV['JUMP_KEYS_POSITION']
-KEYS = 'jfhgkdlsa'.each_char.to_a
+KEYS = ENV['JUMP_KEYS'].each_char.to_a
 Config = Struct.new(
   :pane_nr,
   :pane_tty_file,

--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -8,4 +8,5 @@ source $current_dir/utils.sh
 export JUMP_BACKGROUND_COLOR=$(get_tmux_option "@jump-bg-color" "\e[0m\e[32m")
 export JUMP_FOREGROUND_COLOR=$(get_tmux_option "@jump-fg-color" "\e[1m\e[31m")
 export JUMP_KEYS_POSITION=$(get_tmux_option "@jump-keys-position" "left")
+export JUMP_KEYS=$(get_tmux_option "@jump-keys" "jfhgkdlsa")
 ruby "$current_dir/tmux-jump.rb" "$tmp_file"


### PR DESCRIPTION
Thank you for the really nice package! I love using jump mode, but I also use a Dvorak keyboard layout so the default keybindings are not naturally for me. This patch allows users to customize the keys used for the jump.

Any feedback for changes to get this merged would be greatly appreciated :)