### PR TITLE
Allow configuration of custom jump characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ set -g @jump-keys-position 'off_left'
 ```
 
 And the jump characters used to label positions (default: `jfhgkdlsa`):
+
 ```
-set -g @jump-keys 'asdfghjkl'
+set -g @jump-keys 'etinsrch'
 ```
 
 ## Similar Projects

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ set -g @jump-keys-position 'left'
 set -g @jump-keys-position 'off_left'
 ```
 
-And the jump characters used to label positions:
+And the jump characters used to label positions (default: `jfhgkdlsa`):
 ```
-set -g @jump-keys 'jfhgkdlsa'
+set -g @jump-keys 'asdfghjkl'
 ```
 
 ## Similar Projects

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ set -g @jump-keys-position 'left'
 set -g @jump-keys-position 'off_left'
 ```
 
+And the jump characters used to label positions:
+```
+set -g @jump-keys 'jfhgkdlsa'
+```
+
 ## Similar Projects
 
 * [vimium](https://vimium.github.io/)

--- a/scripts/tmux-jump.rb
+++ b/scripts/tmux-jump.rb
@@ -15,7 +15,7 @@ RESTORE_NORMAL_SCREEN = "\e[?1049l"
 
 # CONFIG
 KEYS_POSITION = ENV['JUMP_KEYS_POSITION']
-KEYS = 'jfhgkdlsa'.each_char.to_a
+KEYS = (ENV['JUMP_KEYS'] || 'jfhgkdlsa').each_char.to_a
 Config = Struct.new(
   :pane_nr,
   :pane_tty_file,

--- a/scripts/tmux-jump.sh
+++ b/scripts/tmux-jump.sh
@@ -8,4 +8,5 @@ source $current_dir/utils.sh
 export JUMP_BACKGROUND_COLOR=$(get_tmux_option "@jump-bg-color" "\e[0m\e[32m")
 export JUMP_FOREGROUND_COLOR=$(get_tmux_option "@jump-fg-color" "\e[1m\e[31m")
 export JUMP_KEYS_POSITION=$(get_tmux_option "@jump-keys-position" "left")
+export JUMP_KEYS=$(get_tmux_option "@jump-keys" "jfhgkdlsa")
 ruby "$current_dir/tmux-jump.rb" "$tmp_file"

--- a/tmux-jump.tmux
+++ b/tmux-jump.tmux
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $CURRENT_DIR/scripts/utils.sh
-tmux bind-key -N "Jump to pane location in copy mode" $(get_tmux_option "@jump-key" "j") run-shell -b "$CURRENT_DIR/scripts/tmux-jump.sh"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/scripts/utils.sh"
+tmux bind-key -N "Jump to pane location in copy mode" "$(get_tmux_option "@jump-key" "j")" run-shell -b "${CURRENT_DIR}/scripts/tmux-jump.sh"


### PR DESCRIPTION
So far, the jump characters are hardcoded to the application. Everyone
has to use exactly these.

However, some users may find them inconvenient to use. I for myself
use a custom keyboard layout, [Noted](https://www.neo-layout.org/Layouts/noted/)
where the default characters are very inconvenient to reach. I'd rather
have jump characters on the home row.

This PR extends tmux-jump such that the jump characters can be specified
in the configuration file. I am using this on my own for about a week
now without issues.

**Disclaimer:** The changes were implemented by Github Copilot and
reviewed by me.

