### PR TITLE
Fix incorrect jump position regression of Tmux 3.7

### DIFF
--- a/scripts/tmux-jump.rb
+++ b/scripts/tmux-jump.rb
@@ -154,6 +154,24 @@ def positions_of(jump_to_char, screen_chars)
   positions
 end
 
+def row_col_for(position, screen_chars)
+  row = 0
+  col = 0
+
+  screen_chars.each_char.with_index do |char, i|
+    break if i == position
+
+    if char == "\n"
+      row += 1
+      col = 0
+    else
+      col += 1
+    end
+  end
+
+  [row, col]
+end
+
 def draw_keys_onto_tty(screen_chars, positions, keys, key_len)
   File.open(Config.pane_tty_file, 'a') do |tty|
     cursor = 0
@@ -213,6 +231,7 @@ def main
   end
   Kernel.exit 0 if position_index.nil?
   jump_to = positions[position_index]
+  jump_row, jump_col = row_col_for jump_to, screen_chars
   `tmux copy-mode -t #{Config.pane_nr}`
    # begin: tmux weirdness when 1st line is empty
   `tmux send-keys -X -t #{Config.pane_nr} start-of-line`
@@ -222,7 +241,8 @@ def main
   `tmux send-keys -X -t #{Config.pane_nr} start-of-line`
   `tmux send-keys -X -t #{Config.pane_nr} top-line`
   `tmux send-keys -X -t #{Config.pane_nr} -N #{Config.scroll_position} cursor-up`
-  `tmux send-keys -X -t #{Config.pane_nr} -N #{jump_to} cursor-right`
+  `tmux send-keys -X -t #{Config.pane_nr} -N #{jump_row} cursor-down` if jump_row > 0
+  `tmux send-keys -X -t #{Config.pane_nr} -N #{jump_col} cursor-right` if jump_col > 0
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/spec/tmux_jump_spec.rb
+++ b/spec/tmux_jump_spec.rb
@@ -205,4 +205,32 @@ RSpec.describe 'tmux-jump' do
       expect(result_queue.pop).to eq nil
     end
   end
+
+  describe '#main' do
+    it 'moves by row and column instead of a flat cursor-right count' do
+      tmp_file = Tempfile.new('tmux-jump-spec')
+      Config.tmp_file = tmp_file.path
+      Config.scroll_position = 0
+      Config.pane_height = 3
+
+      allow(self).to receive(:read_char_from_file!).and_return('e')
+      allow(self).to receive(:recover_screen_after).and_yield
+      allow(self).to receive(:prompt_position_index!).with([3, 22, 59], simple_screen).and_return(2)
+
+      expect(self).to receive(:`).with('tmux capture-pane -p -t %68 -S 0 -E 2').ordered.and_return("#{simple_screen}\n")
+      expect(self).to receive(:`).with('tmux copy-mode -t %68').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 start-of-line').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 top-line').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 -N 200 cursor-right').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 start-of-line').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 top-line').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 -N 0 cursor-up').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 -N 1 cursor-down').ordered.and_return('')
+      expect(self).to receive(:`).with('tmux send-keys -X -t %68 -N 13 cursor-right').ordered.and_return('')
+
+      main
+    ensure
+      tmp_file&.close!
+    end
+  end
 end

--- a/spec/tmux_jump_spec.rb
+++ b/spec/tmux_jump_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe 'tmux-jump' do
     end
   end
 
+  describe '#row_col_for' do
+    it 'returns the correct row and column for positions after a newline' do
+      expect(row_col_for(9, simple_screen)).to eq [0, 9]
+      expect(row_col_for(46, simple_screen)).to eq [1, 0]
+      expect(row_col_for(59, simple_screen)).to eq [1, 13]
+    end
+  end
+
   describe 'keys_for' do
     [
       [1, KEYS.size, 1],


### PR DESCRIPTION
This branch should fix that tmux-jump's jump location is off by one
character per line. This is discussed at #46 and the implementation
provided here matches the solution sketched in that issue.

The implementation, including the test, was provided by Github's
Copilot. I don't know Ruby well enough to do so.

I am using this branch on two machines for a few weeks now,
successfully.